### PR TITLE
use eval instead of JSON5.parse to support function arguments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,7 +107,7 @@ const App: React.FC = () => {
       </div>
 
       <p>
-        <i>Note:</i> The input/output can't include functions.
+        <i>Note:</i> The output can't include functions.
       </p>
       <footer>
         Brought to you by{" "}

--- a/src/lodashMatches.tsx
+++ b/src/lodashMatches.tsx
@@ -2,12 +2,12 @@ import lodash from "lodash";
 import JSON5 from "json5";
 
 export default function(input: string, output: string): LodashFnsResponse {
-  const inputJSONString = `[${input}]`;
+  const inputJSString = `[${input}]`;
   const outputJSONString = `${output}`;
   let inputArgs: any[] = [];
   try {
     // eslint-disable-next-line no-eval
-    inputArgs = eval(inputJSONString);
+    inputArgs = eval(inputJSString);
   } catch (e) {
     return {
       matchingFns: [],

--- a/src/lodashMatches.tsx
+++ b/src/lodashMatches.tsx
@@ -6,11 +6,12 @@ export default function(input: string, output: string): LodashFnsResponse {
   const outputJSONString = `${output}`;
   let inputArgs: any[] = [];
   try {
-    inputArgs = JSON5.parse(inputJSONString);
+    // eslint-disable-next-line no-eval
+    inputArgs = eval(inputJSONString);
   } catch (e) {
     return {
       matchingFns: [],
-      inputError: `Problem parsing: ${removeJSON5(e.toString())}`,
+      inputError: `Problem parsing: ${e.toString()}`,
       outputError: null
     };
   }


### PR DESCRIPTION
JSON does not support functions, so it's an ill suited data structure for finding lodash functions, which often take function arguments. This pull request replaces JSON5.parse with eval when processing the input parameters so that function argument taking lodash functions such as xorWith, unionWith, etc. can be found.

Eval has been a controversial function since long because of the potential of misuse, and the general consensus is to just avoid it altogether. However, there are legitimate use cases for it, as this PR illustrates. Further reading and justification for using it: https://humanwhocodes.com/blog/2013/06/25/eval-isnt-evil-just-misunderstood/